### PR TITLE
Add missing dependency for 'requests' version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'pylxd>=2.2,<3.0',
         'PyYAML>=3.0,<4.0',
         'voluptuous>=0.9,<1.0',
+        'requests!=2.8.0,>=2.5.2',
     ],
     tests_require=[
         'pytest',


### PR DESCRIPTION
I tried to run `sudo python3 setup.py install` but I got that error message :

```
error: requests 2.4.3 is installed but requests!=2.8.0,>=2.5.2 is required
```

This patch fixes that issue.